### PR TITLE
Allow Yapper Metrics domain to fix broken image

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,6 +15,12 @@ const nextConfig: NextConfig = {
         port: '',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'yapper-metrics.vercel.app',
+        port: '',
+        pathname: '/**',
+      },
     ],
   },
 };


### PR DESCRIPTION
NextJS config is only allowing Github domain for images, but the repo is private.